### PR TITLE
feat : apply unique s3 backet name for stacks

### DIFF
--- a/common_mk/Makefile
+++ b/common_mk/Makefile
@@ -2,8 +2,6 @@ CURRENT_DIR := $(shell pwd)
 COMMONMK_DIR=${CURRENT_DIR}/aws-sam-template/common_mk
 include ${COMMONMK_DIR}/common.mk
 
-S3_TEMPLATE_BUCKET=
-
 prepare-venv:
 	@bash -c "\
 	  cd ${COMMONMK_DIR}/.. && \
@@ -15,11 +13,6 @@ stack:
 	if [[ ! -d ${COMMONMK_DIR}/../venv ]]; then \
 		make prepare-venv; \
 	fi
-	@if [[ -z "${S3_TEMPLATE_BUCKET}" ]]; then \
-		echo "### set unique s3 backet name to S3_TEMPLATE_BUCKET in Makefile"; \
-		echo; \
-	else \
-		mkdir ${name}-stack; \
-		cp -RP ${COMMONMK_DIR}/template_sam/* ${name}-stack; \
-		cd ${name}-stack && sed -i -e 's/S3_TEMPLATE_BUCKET=/S3_TEMPLATE_BUCKET=${S3_TEMPLATE_BUCKET}/' Makefile; \
-	fi
+	mkdir ${name}-stack; \
+	cp -RP ${COMMONMK_DIR}/template_sam/* ${name}-stack;
+

--- a/common_mk/deploy.mk
+++ b/common_mk/deploy.mk
@@ -1,8 +1,7 @@
-AWS_ACCOUNT_ID=$(shell aws sts get-caller-identity --profile ${PROFILE} | jq -r ."Account") 
-STACK_NAME_LCASE=$(shell echo ${STACK_NAME} | tr A-Z a-z)
-S3_TEMPLATE_BUCKET=$(shell echo ${AWS_ACCOUNT_ID}-${STACK_NAME_LCASE}-sam | tr -d ' ')
-
 package:
+	@$(eval AWS_ACCOUNT_ID := $(shell aws sts get-caller-identity --profile $(PROFILE) | jq -r ."Account"))
+	@$(eval STACK_NAME_LCASE := $(shell echo $(STACK_NAME) | tr A-Z a-z))
+	@$(eval S3_TEMPLATE_BUCKET := $(AWS_ACCOUNT_ID)-$(STACK_NAME_LCASE)-sam)
 	if [[ -z `. ${SAMDIR}/venv/bin/activate && ${AWSCLI} s3 ls --profile ${PROFILE} | grep ${S3_TEMPLATE_BUCKET}-${PROFILE}` ]]; then \
 		$(SHELL) -c "\
 		    . ${SAMDIR}/venv/bin/activate && \

--- a/common_mk/deploy.mk
+++ b/common_mk/deploy.mk
@@ -1,3 +1,6 @@
+AWS_ACCOUNT_ID=$(shell aws sts get-caller-identity --profile ${PROFILE} | jq -r ."Account") 
+STACK_NAME_LCASE=$(shell echo ${STACK_NAME} | tr A-Z a-z)
+S3_TEMPLATE_BUCKET=$(shell echo ${AWS_ACCOUNT_ID}-${STACK_NAME_LCASE}-sam | tr -d ' ')
 
 package:
 	if [[ -z `. ${SAMDIR}/venv/bin/activate && ${AWSCLI} s3 ls --profile ${PROFILE} | grep ${S3_TEMPLATE_BUCKET}-${PROFILE}` ]]; then \


### PR DESCRIPTION
スタックのデプロイパッケージの格納先のS3バケット名を、aws accountやスタック名を絡めた名前にするように変更いたしました。
これにより、バケット名が衝突することによるデプロイの失敗を避けられます。